### PR TITLE
Optimize creation of SEL

### DIFF
--- a/dart_native/lib/src/ios/runtime/selector.dart
+++ b/dart_native/lib/src/ios/runtime/selector.dart
@@ -7,34 +7,32 @@ class SEL {
   String name;
   Pointer<Void> _selPtr;
 
-  static final Map<int, SEL> _cache = <int, SEL>{};
+  static final Map<String, SEL> _cache = <String, SEL>{};
 
   factory SEL(String selectorName) {
     if (selectorName == null) {
       return null;
     }
+    if (_cache.containsKey(selectorName)) {
+      return _cache[selectorName];
+    }
     final selectorNamePtr = Utf8.toUtf8(selectorName);
     Pointer<Void> ptr = sel_registerName(selectorNamePtr);
     free(selectorNamePtr);
-    if (_cache.containsKey(ptr.address)) {
-      return _cache[ptr.address];
-    } else {
-      return SEL._internal(selectorName, ptr);
-    }
+    return SEL._internal(selectorName, ptr);
   }
 
   factory SEL.fromPointer(Pointer<Void> ptr) {
-    int key = ptr.address;
-    if (_cache.containsKey(key)) {
-      return _cache[key];
+    String selName = Utf8.fromUtf8(sel_getName(ptr));
+    if (_cache.containsKey(selName)) {
+      return _cache[selName];
     } else {
-      String selName = Utf8.fromUtf8(sel_getName(ptr));
       return SEL._internal(selName, ptr);
     }
   }
 
   SEL._internal(this.name, this._selPtr) {
-    _cache[_selPtr.address] = this;
+    _cache[this.name] = this;
   }
 
   Pointer<Void> toPointer() {


### PR DESCRIPTION
We don't need to use `SEL` as the `_cache` `key`, use `selectorName` directly. We can prevent duplicate operations if same `SEL` already existed https://github.com/zhongwuzw/dart_native/blob/1e077faeb94b25274e9d45afe0cd24bd75ed5b9b/dart_native/lib/src/ios/runtime/selector.dart#L19-L21 .