### PR TITLE
FIX: 特定安卓机型，调用出现crash『JNI ERROR (app bug): local reference table over…

### DIFF
--- a/dart_native/android/src/main/jni/dn_method_call.cpp
+++ b/dart_native/android/src/main/jni/dn_method_call.cpp
@@ -71,5 +71,7 @@ void *callNativeVoidMethod(JNIEnv *env, jobject object, jmethodID methodId, jval
 void *callNativeStringMethod(JNIEnv *env, jobject object, jmethodID methodId, jvalue *arguments)
 {
   auto javaString = (jstring)env->CallObjectMethodA(object, methodId, arguments);
-  return convertToDartUtf16(env, javaString);
+  void *ret = convertToDartUtf16(env, javaString);
+  env->DeleteLocalRef(javaString);
+  return ret;
 }

--- a/dart_native/android/src/main/jni/dn_type_convert.cpp
+++ b/dart_native/android/src/main/jni/dn_type_convert.cpp
@@ -17,6 +17,10 @@ jstring convertToJavaUtf16(JNIEnv *env, void *value, jvalue *argValue, int index
   jstring nativeString = env->NewString(utf16, length);
   free(value);
 
+//  char *cString = (char *) env->GetStringUTFChars(nativeString, NULL);
+//  DNDebug("convertToJavaUtf16 length=%d, %s", length, cString);
+//  env->ReleaseStringUTFChars(nativeString, cString);
+
   if (argValue != nullptr)
   {
     argValue[index].l = nativeString;

--- a/dart_native/example/android/app/src/main/java/com/dartnative/dart_native_example/MainActivity.java
+++ b/dart_native/example/android/app/src/main/java/com/dartnative/dart_native_example/MainActivity.java
@@ -30,6 +30,7 @@ public class MainActivity extends FlutterActivity {
           result.success(100);
         } else if ("fooString".equals(call.method)) {
           result.success(call.arguments);
+        } else if ("setFooString".equals(call.method)) {
         } else {
           result.notImplemented();
         }

--- a/dart_native/example/android/app/src/main/java/com/dartnative/dart_native_example/RuntimeStub.java
+++ b/dart_native/example/android/app/src/main/java/com/dartnative/dart_native_example/RuntimeStub.java
@@ -52,6 +52,10 @@ public class RuntimeStub {
         return true;
     }
 
+    public void setString(String s) {
+    //    Log.d(TAG, "setString : " + s);
+    }
+
     public String getString(String s) {
     //    Log.d(TAG, "getString : " + s);
        return "This is a long string: sdlfdksjflksndhiofuu2893873(*（%￥#@）*&……￥撒肥料开发时傅雷家书那份会计师东方丽景三等奖";

--- a/dart_native/example/ios/Runner/AppDelegate.m
+++ b/dart_native/example/ios/Runner/AppDelegate.m
@@ -28,6 +28,8 @@
     [channel setMethodCallHandler:^(FlutterMethodCall *call, FlutterResult result) {
         if ([call.method isEqualToString:@"fooString"]) {
             result([son fooNSString:call.arguments]);
+        } else if ([call.method isEqualToString:@"setFooString"]) {
+            [son fooNSString:call.arguments];
         }
     }];
     [GeneratedPluginRegistrant registerWithRegistry:self];

--- a/dart_native/example/ios/Runner/RuntimeStub.h
+++ b/dart_native/example/ios/Runner/RuntimeStub.h
@@ -70,6 +70,7 @@ typedef CGFloat (^CGFloatRetBlock)(CGFloat a);
 - (void)fooDelegate:(id<SampleDelegate>)delegate;
 - (void)fooStructDelegate:(id<SampleDelegate>)delegate;
 - (NSString *)fooNSString:(NSString *)str;
+- (void)setFooNSString:(NSString *)str;
 - (NSMutableString *)fooNSMutableString:(NSMutableString *)str;
 - (BOOL)fooWithError:(out NSError **)error;
 - (TestOptions)fooWithOptions:(TestOptions)options;

--- a/dart_native/example/ios/Runner/RuntimeStub.m
+++ b/dart_native/example/ios/Runner/RuntimeStub.m
@@ -261,6 +261,10 @@ API_AVAILABLE(ios(11.0)){
     return @"test nsstring";
 }
 
+- (void)setFooNSString:(NSString *)str {
+//    DDLogInfo(@"%s arg: %@", __FUNCTION__, str);
+}
+
 - (NSMutableString *)fooNSMutableString:(NSMutableString *)str {
     [str appendString:@" mutable!"];
     DDLogInfo(@"%s arg: %@", __FUNCTION__, str);

--- a/dart_native/example/lib/android/runtimestub.dart
+++ b/dart_native/example/lib/android/runtimestub.dart
@@ -56,6 +56,10 @@ class RuntimeStub extends JObject {
     return invoke('getString', [s], "Ljava/lang/String;");
   }
 
+  String setString(String s) {
+    return invoke('setString', [s], "V");
+  }
+
   int add(int a, int b) {
     return invoke('add', [a, b], "I");
   }

--- a/dart_native/example/lib/android/unit_test.dart
+++ b/dart_native/example/lib/android/unit_test.dart
@@ -9,6 +9,11 @@ class DNAndroidUnitTest with DNUnitTestBase {
   final stub = RuntimeStub();
 
   @override
+  void setFooString(String str) {
+    stub.setString(str);
+  }
+
+  @override
   String fooString(String str) {
     return stub.getString(str);
   }

--- a/dart_native/example/lib/dn_unit_test.dart
+++ b/dart_native/example/lib/dn_unit_test.dart
@@ -16,6 +16,10 @@ class DNUnitTest {
     _unitTest = Platform.isAndroid ? DNAndroidUnitTest() : DNIOSUnitTest();
   }
 
+  void setFooString(String str) {
+    _unitTest.setFooString(str);
+  }
+
   String fooString(String str) {
     return _unitTest.fooString(str);
   }
@@ -30,6 +34,7 @@ class DNUnitTest {
 /// Base class for all platform.
 ///
 abstract class DNUnitTestBase {
+  void setFooString(String str);
   String fooString(String str);
 
   void runAllUnitTests();

--- a/dart_native/example/lib/ios/runtimestub.dart
+++ b/dart_native/example/lib/ios/runtimestub.dart
@@ -243,6 +243,10 @@ class RuntimeStub extends NSObject {
     perform(SEL('fooStructDelegate:'), args: [delegate]);
   }
 
+  void setFooNSString(String str) {
+    perform(SEL('setFooNSString:'), args: [str]);
+  }
+
   String fooNSString(String str) {
     return perform(SEL('fooNSString:'), args: [str]);
   }

--- a/dart_native/example/lib/ios/unit_test.dart
+++ b/dart_native/example/lib/ios/unit_test.dart
@@ -14,6 +14,11 @@ class DNIOSUnitTest with DNUnitTestBase {
   final delegate = DelegateStub();
 
   @override
+  void setFooString(String str) {
+    stub.setFooNSString(str);
+  }
+
+  @override
   String fooString(String str) {
     return stub.fooNSString(str);
   }

--- a/dart_native/example/lib/main.dart
+++ b/dart_native/example/lib/main.dart
@@ -30,10 +30,25 @@ class _DartNativeAppState extends State<DartNativeApp> {
   Future<void> initPlatformState() async {
     final unitTest = DNUnitTest();
 
+    String testString = "";
+    int time = 0;
     /// Benchmark
-    String testString =
+    testString =
         'This is a long string: sdlfdksjflksndhiofuu2893873(*（%￥#@）*&……￥撒肥料开发时傅雷家书那份会计师东方丽景三等奖';
-    int time = DateTime.now().millisecondsSinceEpoch;
+    time = DateTime.now().millisecondsSinceEpoch;
+    for (var i = 0; i < 10000; i++) {
+      platform.invokeMethod('setFooString', testString);
+    }
+    print(
+        "Flutter Channel Cost: ${DateTime.now().millisecondsSinceEpoch - time}");
+
+    time = DateTime.now().millisecondsSinceEpoch;
+    for (var i = 0; i < 10000; i++) {
+      unitTest.setFooString(testString);
+    }
+    print("DartNative Cost: ${DateTime.now().millisecondsSinceEpoch - time}");
+
+    time = DateTime.now().millisecondsSinceEpoch;
     for (var i = 0; i < 10000; i++) {
       String _ = await platform.invokeMethod('fooString', testString);
     }


### PR DESCRIPTION
手里有一台vivo x9，rom Funtouch OS_3.1，会在调用时crash
发现代码里存在Android JNI局部引用表溢出的情况，尝试修复解决


08-26 14:37:22.481 15728 15751 F art     : art/runtime/indirect_reference_table.cc:132] JNI ERROR (app bug): local reference table overflow (max=512)
08-26 14:37:22.481 15728 15751 F art     : art/runtime/indirect_reference_table.cc:132] local reference table dump:
08-26 14:37:22.481 15728 15751 F art     : art/runtime/indirect_reference_table.cc:132]   Last 10 entries (of 512):
08-26 14:37:22.481 15728 15751 F art     : art/runtime/indirect_reference_table.cc:132]       511: 0x12de87c0 java.lang.String "This is a long s... (85 chars)
08-26 14:37:22.481 15728 15751 F art     : art/runtime/indirect_reference_table.cc:132]       510: 0x12df6340 java.lang.String "This is a long s... (85 chars)
08-26 14:37:22.481 15728 15751 F art     : art/runtime/indirect_reference_table.cc:132]       509: 0x12de87c0 java.lang.String "This is a long s... (85 chars)
08-26 14:37:22.481 15728 15751 F art     : art/runtime/indirect_reference_table.cc:132]       508: 0x12df6280 java.lang.String "This is a long s... (85 chars)
08-26 14:37:22.481 15728 15751 F art     : art/runtime/indirect_reference_table.cc:132]       507: 0x12de87c0 java.lang.String "This is a long s... (85 chars)
08-26 14:37:22.481 15728 15751 F art     : art/runtime/indirect_reference_table.cc:132]       506: 0x12df61c0 java.lang.String "This is a long s... (85 chars)
08-26 14:37:22.481 15728 15751 F art     : art/runtime/indirect_reference_table.cc:132]       505: 0x12de87c0 java.lang.String "This is a long s... (85 chars)
08-26 14:37:22.481 15728 15751 F art     : art/runtime/indirect_reference_table.cc:132]       504: 0x12df6100 java.lang.String "This is a long s... (85 chars)
08-26 14:37:22.481 15728 15751 F art     : art/runtime/indirect_reference_table.cc:132]       503: 0x12de87c0 java.lang.String "This is a long s... (85 chars)
08-26 14:37:22.481 15728 15751 F art     : art/runtime/indirect_reference_table.cc:132]       502: 0x12df5f40 java.lang.String "This is a long s... (85 chars)
08-26 14:37:22.481 15728 15751 F art     : art/runtime/indirect_reference_table.cc:132]   Summary:
08-26 14:37:22.481 15728 15751 F art     : art/runtime/indirect_reference_table.cc:132]       511 of java.lang.String (257 unique instances)
08-26 14:37:22.481 15728 15751 F art     : art/runtime/indirect_reference_table.cc:132]         1 of java.lang.ClassNotFoundException
08-26 14:37:22.481 15728 15751 F art     : art/runtime/indirect_reference_table.cc:132] 
08-26 14:37:22.540 15728 15751 F art     : art/runtime/runtime.cc:426] Runtime aborting...
08-26 14:37:22.540 15728 15751 F art     : art/runtime/runtime.cc:426] Aborting thread:
08-26 14:37:22.540 15728 15751 F art     : art/runtime/runtime.cc:426] "Thread-2" prio=6 tid=18 Runnable
08-26 14:37:22.540 15728 15751 F art     : art/runtime/runtime.cc:426]   | group="" sCount=0 dsCount=0 obj=0x12d541f0 self=0x7f86284a00
08-26 14:37:22.540 15728 15751 F art     : art/runtime/runtime.cc:426]   | sysTid=15751 nice=-1 cgrp=default sched=0/0 handle=0x7f87ee9450
08-26 14:37:22.540 15728 15751 F art     : art/runtime/runtime.cc:426]   | state=R schedstat=( 8198358266 771922193 32992 ) utm=713 stm=106 core=6 HZ=100
08-26 14:37:22.540 15728 15751 F art     : art/runtime/runtime.cc:426]   | stack=0x7f87def000-0x7f87df1000 stackSize=1005KB
08-26 14:37:22.540 15728 15751 F art     : art/runtime/runtime.cc:426]   | held mutexes= "abort lock" "mutator lock"(shared held)
08-26 14:37:22.540 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #00 pc 000000000047b0c0  /system/lib64/libart.so (_ZN3art15DumpNativeStackERNSt3__113basic_ostreamIcNS0_11char_traitsIcEEEEiP12BacktraceMapPKcPNS_9ArtMethodEPv+220)
08-26 14:37:22.540 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #01 pc 000000000047b0bc  /system/lib64/libart.so (_ZN3art15DumpNativeStackERNSt3__113basic_ostreamIcNS0_11char_traitsIcEEEEiP12BacktraceMapPKcPNS_9ArtMethodEPv+216)
08-26 14:37:22.540 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #02 pc 000000000044f5e8  /system/lib64/libart.so (_ZNK3art6Thread9DumpStackERNSt3__113basic_ostreamIcNS1_11char_traitsIcEEEEbP12BacktraceMap+472)
08-26 14:37:22.540 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #03 pc 000000000043d668  /system/lib64/libart.so (_ZNK3art10AbortState10DumpThreadERNSt3__113basic_ostreamIcNS1_11char_traitsIcEEEEPNS_6ThreadE+56)
08-26 14:37:22.540 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #04 pc 000000000043d488  /system/lib64/libart.so (_ZNK3art10AbortState4DumpERNSt3__113basic_ostreamIcNS1_11char_traitsIcEEEE+576)
08-26 14:37:22.540 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #05 pc 0000000000430f6c  /system/lib64/libart.so (_ZN3art7Runtime5AbortEPKc+144)
08-26 14:37:22.540 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #06 pc 00000000000e5918  /system/lib64/libart.so (_ZN3art10LogMessageD2Ev+1576)
08-26 14:37:22.540 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #07 pc 000000000024c4b4  /system/lib64/libart.so (_ZN3art22IndirectReferenceTable3AddEjPNS_6mirror6ObjectE+308)
08-26 14:37:22.540 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #08 pc 0000000000349ac0  /system/lib64/libart.so (_ZN3art3JNI9NewStringEP7_JNIEnvPKti+628)
08-26 14:37:22.540 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #09 pc 00000000000f9e70  /system/lib64/libart.so (_ZN3art8CheckJNI9NewStringEP7_JNIEnvPKti+668)
08-26 14:37:22.540 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #10 pc 000000000003e28c  /data/app/com.dartnative.dart_native_example-1/lib/arm64/libdart_native.so (_ZN7_JNIEnv9NewStringEPKti+48)
08-26 14:37:22.540 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #11 pc 000000000003e20c  /data/app/com.dartnative.dart_native_example-1/lib/arm64/libdart_native.so (convertToJavaUtf16+124)
08-26 14:37:22.540 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #12 pc 000000000002fc18  /data/app/com.dartnative.dart_native_example-1/lib/arm64/libdart_native.so (_fillArgs+228)
08-26 14:37:22.540 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #13 pc 0000000000030188  /data/app/com.dartnative.dart_native_example-1/lib/arm64/libdart_native.so (invokeNativeMethod+212)
08-26 14:37:22.540 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #14 pc 0000000000005674   (???)
08-26 14:37:22.540 15728 15751 F art     : art/runtime/runtime.cc:426]   (no managed stack frames)
08-26 14:37:22.540 15728 15751 F art     : art/runtime/runtime.cc:426] Dumping all threads without appropriate locks held: thread list lock
08-26 14:37:22.540 15728 15751 F art     : art/runtime/runtime.cc:426] All threads:
08-26 14:37:22.540 15728 15751 F art     : art/runtime/runtime.cc:426] DALVIK THREADS (16):
08-26 14:37:22.540 15728 15751 F art     : art/runtime/runtime.cc:426] "Thread-2" prio=6 tid=18 Runnable
08-26 14:37:22.540 15728 15751 F art     : art/runtime/runtime.cc:426]   | group="" sCount=0 dsCount=0 obj=0x12d541f0 self=0x7f86284a00
08-26 14:37:22.540 15728 15751 F art     : art/runtime/runtime.cc:426]   | sysTid=15751 nice=-1 cgrp=default sched=0/0 handle=0x7f87ee9450
08-26 14:37:22.540 15728 15751 F art     : art/runtime/runtime.cc:426]   | state=R schedstat=( 8227873110 771922193 32992 ) utm=716 stm=106 core=6 HZ=100
08-26 14:37:22.540 15728 15751 F art     : art/runtime/runtime.cc:426]   | stack=0x7f87def000-0x7f87df1000 stackSize=1005KB
08-26 14:37:22.540 15728 15751 F art     : art/runtime/runtime.cc:426]   | held mutexes= "abort lock" "mutator lock"(shared held)
08-26 14:37:22.540 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #00 pc 000000000047b0c0  /system/lib64/libart.so (_ZN3art15DumpNativeStackERNSt3__113basic_ostreamIcNS0_11char_traitsIcEEEEiP12BacktraceMapPKcPNS_9ArtMethodEPv+220)
08-26 14:37:22.540 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #01 pc 000000000047b0bc  /system/lib64/libart.so (_ZN3art15DumpNativeStackERNSt3__113basic_ostreamIcNS0_11char_traitsIcEEEEiP12BacktraceMapPKcPNS_9ArtMethodEPv+216)
08-26 14:37:22.540 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #02 pc 000000000044f5e8  /system/lib64/libart.so (_ZNK3art6Thread9DumpStackERNSt3__113basic_ostreamIcNS1_11char_traitsIcEEEEbP12BacktraceMap+472)
08-26 14:37:22.540 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #03 pc 0000000000466f4c  /system/lib64/libart.so (_ZN3art14DumpCheckpoint3RunEPNS_6ThreadE+820)
08-26 14:37:22.540 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #04 pc 000000000045f228  /system/lib64/libart.so (_ZN3art10ThreadList13RunCheckpointEPNS_7ClosureE+456)
08-26 14:37:22.540 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #05 pc 000000000045ee2c  /system/lib64/libart.so (_ZN3art10ThreadList4DumpERNSt3__113basic_ostreamIcNS1_11char_traitsIcEEEEb+848)
08-26 14:37:22.540 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #06 pc 000000000043d498  /system/lib64/libart.so (_ZNK3art10AbortState4DumpERNSt3__113basic_ostreamIcNS1_11char_traitsIcEEEE+592)
08-26 14:37:22.540 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #07 pc 0000000000430f6c  /system/lib64/libart.so (_ZN3art7Runtime5AbortEPKc+144)
08-26 14:37:22.540 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #08 pc 00000000000e5918  /system/lib64/libart.so (_ZN3art10LogMessageD2Ev+1576)
08-26 14:37:22.540 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #09 pc 000000000024c4b4  /system/lib64/libart.so (_ZN3art22IndirectReferenceTable3AddEjPNS_6mirror6ObjectE+308)
08-26 14:37:22.540 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #10 pc 0000000000349ac0  /system/lib64/libart.so (_ZN3art3JNI9NewStringEP7_JNIEnvPKti+628)
08-26 14:37:22.540 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #11 pc 00000000000f9e70  /system/lib64/libart.so (_ZN3art8CheckJNI9NewStringEP7_JNIEnvPKti+668)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #12 pc 000000000003e28c  /data/app/com.dartnative.dart_native_example-1/lib/arm64/libdart_native.so (_ZN7_JNIEnv9NewStringEPKti+48)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #13 pc 000000000003e20c  /data/app/com.dartnative.dart_native_example-1/lib/arm64/libdart_native.so (convertToJavaUtf16+124)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #14 pc 000000000002fc18  /data/app/com.dartnative.dart_native_example-1/lib/arm64/libdart_native.so (_fillArgs+228)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #15 pc 0000000000030188  /data/app/com.dartnative.dart_native_example-1/lib/arm64/libdart_native.so (invokeNativeMethod+212)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #16 pc 0000000000005674   (???)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   (no managed stack frames)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426] 
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426] "main" prio=6 tid=1 Native
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   | group="" sCount=1 dsCount=0 obj=0x76735b50 self=0x7fa7a97e00
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   | sysTid=15728 nice=-10 cgrp=default sched=0/0 handle=0x7fac4cfa98
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   | state=S schedstat=( 3735619384 421972845 27641 ) utm=282 stm=91 core=4 HZ=100
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   | stack=0x7fdce97000-0x7fdce99000 stackSize=8MB
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   | held mutexes=
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: __switch_to+0x7c/0x88
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: SyS_epoll_wait+0x2d4/0x394
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: SyS_epoll_pwait+0xc4/0x150
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: cpu_switch_to+0x210/0x5a0
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #00 pc 000000000006abb8  /system/lib64/libc.so (__epoll_pwait+8)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #01 pc 000000000001e574  /system/lib64/libc.so (epoll_pwait+64)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #02 pc 0000000000018160  /system/lib64/libutils.so (_ZN7android6Looper9pollInnerEi+156)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #03 pc 0000000000018014  /system/lib64/libutils.so (_ZN7android6Looper8pollOnceEiPiS1_PPv+60)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #04 pc 00000000000f3128  /system/lib64/libandroid_runtime.so (_ZN7android18NativeMessageQueue8pollOnceEP7_JNIEnvP8_jobjecti+48)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #05 pc 00000000008ddc60  /system/framework/arm64/boot-framework.oat (Java_android_os_MessageQueue_nativePollOnce__JI+140)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   at android.os.MessageQueue.nativePollOnce(Native method)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   at android.os.MessageQueue.next(MessageQueue.java:323)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   at android.os.Looper.loop(Looper.java:136)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   at android.app.ActivityThread.main(ActivityThread.java:6211)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   at java.lang.reflect.Method.invoke!(Native method)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:903)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:793)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426] 
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426] "Jit thread pool worker thread 0" prio=6 tid=2 Native
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   | group="" sCount=1 dsCount=0 obj=0x12c37f70 self=0x7f9f60d000
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   | sysTid=15733 nice=9 cgrp=default sched=0/0 handle=0x7fa7005450
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   | state=S schedstat=( 36097709 6017395 34 ) utm=2 stm=1 core=6 HZ=100
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   | stack=0x7fa6f07000-0x7fa6f09000 stackSize=1021KB
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   | held mutexes=
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: __switch_to+0x7c/0x88
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: futex_wait_queue_me+0xe4/0x144
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: futex_wait+0xfc/0x208
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: do_futex+0xdc/0x8a4
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: SyS_futex+0x114/0x1a0
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: cpu_switch_to+0x210/0x5a0
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #00 pc 000000000001c1ac  /system/lib64/libc.so (syscall+28)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #01 pc 00000000000e7bc8  /system/lib64/libart.so (_ZN3art17ConditionVariable16WaitHoldingLocksEPNS_6ThreadE+160)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #02 pc 0000000000468cdc  /system/lib64/libart.so (_ZN3art10ThreadPool7GetTaskEPNS_6ThreadE+252)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #03 pc 000000000046818c  /system/lib64/libart.so (_ZN3art16ThreadPoolWorker3RunEv+124)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #04 pc 0000000000467abc  /system/lib64/libart.so (_ZN3art16ThreadPoolWorker8CallbackEPv+132)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #05 pc 000000000006881c  /system/lib64/libc.so (_ZL15__pthread_startPv+196)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #06 pc 000000000001de40  /system/lib64/libc.so (__start_thread+16)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   (no managed stack frames)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426] 
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426] "Signal Catcher" prio=6 tid=3 WaitingInMainSignalCatcherLoop
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   | group="" sCount=1 dsCount=0 obj=0x12c3d0d0 self=0x7f98318e00
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   | sysTid=15734 nice=0 cgrp=default sched=0/0 handle=0x7fa6f04450
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   | state=S schedstat=( 222292 0 1 ) utm=0 stm=0 core=7 HZ=100
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   | stack=0x7fa6e0a000-0x7fa6e0c000 stackSize=1005KB
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   | held mutexes=
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: __switch_to+0x7c/0x88
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: do_sigtimedwait+0xec/0x1d8
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: SyS_rt_sigtimedwait+0xd4/0x124
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: cpu_switch_to+0x210/0x5a0
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #00 pc 000000000006ad98  /system/lib64/libc.so (__rt_sigtimedwait+8)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #01 pc 0000000000024fa0  /system/lib64/libc.so (sigwait+64)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #02 pc 0000000000441d34  /system/lib64/libart.so (_ZN3art9SignalSet4WaitEv+48)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #03 pc 0000000000441804  /system/lib64/libart.so (_ZN3art13SignalCatcher13WaitForSignalEPNS_6ThreadERNS_9SignalSetE+240)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #04 pc 000000000043fdd0  /system/lib64/libart.so (_ZN3art13SignalCatcher3RunEPv+396)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #05 pc 000000000006881c  /system/lib64/libc.so (_ZL15__pthread_startPv+196)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #06 pc 000000000001de40  /system/lib64/libc.so (__start_thread+16)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   (no managed stack frames)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426] 
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426] "JDWP" prio=6 tid=4 WaitingInMainDebuggerLoop
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   | group="" sCount=1 dsCount=0 obj=0x12c3d160 self=0x7f9f616400
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   | sysTid=15735 nice=0 cgrp=default sched=0/0 handle=0x7fa6e07450
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   | state=S schedstat=( 1373384 210833 8 ) utm=0 stm=0 core=7 HZ=100
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   | stack=0x7fa6d0d000-0x7fa6d0f000 stackSize=1005KB
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   | held mutexes=
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: __switch_to+0x7c/0x88
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: poll_schedule_timeout+0x44/0x68
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: do_select+0x4cc/0x524
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: core_sys_select+0x208/0x324
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: SyS_pselect6+0x18c/0x238
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: cpu_switch_to+0x210/0x5a0
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #00 pc 000000000006acf0  /system/lib64/libc.so (__pselect6+8)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #01 pc 00000000000234b0  /system/lib64/libc.so (select+156)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #02 pc 0000000000553e30  /system/lib64/libart.so (_ZN3art4JDWP12JdwpAdbState15ProcessIncomingEv+340)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #03 pc 00000000003037fc  /system/lib64/libart.so (_ZN3art4JDWP9JdwpState3RunEv+920)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #04 pc 0000000000302cd0  /system/lib64/libart.so (_ZN3art4JDWPL15StartJdwpThreadEPv+48)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #05 pc 000000000006881c  /system/lib64/libc.so (_ZL15__pthread_startPv+196)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #06 pc 000000000001de40  /system/lib64/libc.so (__start_thread+16)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   (no managed stack frames)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426] 
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426] "ReferenceQueueDaemon" prio=6 tid=5 Waiting
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   | group="" sCount=1 dsCount=0 obj=0x12c3d1f0 self=0x7f9831ac00
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   | sysTid=15736 nice=0 cgrp=default sched=0/0 handle=0x7fa6d0a450
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   | state=S schedstat=( 1327135 64166 17 ) utm=0 stm=0 core=7 HZ=100
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   | stack=0x7fa6c08000-0x7fa6c0a000 stackSize=1037KB
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   | held mutexes=
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: __switch_to+0x7c/0x88
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: futex_wait_queue_me+0xe4/0x144
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: futex_wait+0xfc/0x208
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: do_futex+0xdc/0x8a4
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: SyS_futex+0x114/0x1a0
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: cpu_switch_to+0x210/0x5a0
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #00 pc 000000000001c1ac  /system/lib64/libc.so (syscall+28)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #01 pc 00000000000e7bc8  /system/lib64/libart.so (_ZN3art17ConditionVariable16WaitHoldingLocksEPNS_6ThreadE+160)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #02 pc 000000000037a504  /system/lib64/libart.so (_ZN3art7Monitor4WaitEPNS_6ThreadElibNS_11ThreadStateE+660)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #03 pc 0000000000000810  /system/framework/arm64/boot.oat (Java_java_lang_Object_wait__+124)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   at java.lang.Object.wait!(Native method)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   - waiting on <0x09b3d2c8> (a java.lang.Class<java.lang.ref.ReferenceQueue>)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   at java.lang.Daemons$ReferenceQueueDaemon.run(Daemons.java:153)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   - locked <0x09b3d2c8> (a java.lang.Class<java.lang.ref.ReferenceQueue>)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   at java.lang.Thread.run(Thread.java:761)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426] 
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426] "FinalizerDaemon" prio=6 tid=6 Waiting
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   | group="" sCount=1 dsCount=0 obj=0x12c3d280 self=0x7f9831b600
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   | sysTid=15737 nice=0 cgrp=default sched=0/0 handle=0x7fa6c05450
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   | state=S schedstat=( 1689637 80467 15 ) utm=0 stm=0 core=6 HZ=100
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   | stack=0x7fa6b03000-0x7fa6b05000 stackSize=1037KB
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   | held mutexes=
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: __switch_to+0x7c/0x88
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: futex_wait_queue_me+0xe4/0x144
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: futex_wait+0xfc/0x208
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: do_futex+0xdc/0x8a4
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: SyS_futex+0x114/0x1a0
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: cpu_switch_to+0x210/0x5a0
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #00 pc 000000000001c1ac  /system/lib64/libc.so (syscall+28)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #01 pc 00000000000e7bc8  /system/lib64/libart.so (_ZN3art17ConditionVariable16WaitHoldingLocksEPNS_6ThreadE+160)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #02 pc 000000000037a504  /system/lib64/libart.so (_ZN3art7Monitor4WaitEPNS_6ThreadElibNS_11ThreadStateE+660)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #03 pc 0000000000000980  /system/framework/arm64/boot.oat (Java_java_lang_Object_wait__JI+140)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   at java.lang.Object.wait!(Native method)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   - waiting on <0x0a79df61> (a java.lang.Object)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   at java.lang.Object.wait(Object.java:407)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   at java.lang.ref.ReferenceQueue.remove(ReferenceQueue.java:188)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   - locked <0x0a79df61> (a java.lang.Object)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   at java.lang.ref.ReferenceQueue.remove(ReferenceQueue.java:209)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   at java.lang.Daemons$FinalizerDaemon.run(Daemons.java:207)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   at java.lang.Thread.run(Thread.java:761)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426] 
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426] "FinalizerWatchdogDaemon" prio=6 tid=7 Waiting
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   | group="" sCount=1 dsCount=0 obj=0x12c3d310 self=0x7fa7a98800
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   | sysTid=15738 nice=0 cgrp=default sched=0/0 handle=0x7fa6b00450
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   | state=S schedstat=( 381667 183073 8 ) utm=0 stm=0 core=6 HZ=100
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   | stack=0x7fa69fe000-0x7fa6a00000 stackSize=1037KB
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   | held mutexes=
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: __switch_to+0x7c/0x88
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: futex_wait_queue_me+0xe4/0x144
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: futex_wait+0xfc/0x208
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: do_futex+0xdc/0x8a4
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: SyS_futex+0x114/0x1a0
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: cpu_switch_to+0x210/0x5a0
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #00 pc 000000000001c1ac  /system/lib64/libc.so (syscall+28)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #01 pc 00000000000e7bc8  /system/lib64/libart.so (_ZN3art17ConditionVariable16WaitHoldingLocksEPNS_6ThreadE+160)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #02 pc 000000000037a504  /system/lib64/libart.so (_ZN3art7Monitor4WaitEPNS_6ThreadElibNS_11ThreadStateE+660)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #03 pc 0000000000000810  /system/framework/arm64/boot.oat (Java_java_lang_Object_wait__+124)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   at java.lang.Object.wait!(Native method)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   - waiting on <0x0df9da86> (a java.lang.Daemons$FinalizerWatchdogDaemon)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   at java.lang.Daemons$FinalizerWatchdogDaemon.sleepUntilNeeded(Daemons.java:272)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   - locked <0x0df9da86> (a java.lang.Daemons$FinalizerWatchdogDaemon)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   at java.lang.Daemons$FinalizerWatchdogDaemon.run(Daemons.java:252)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   at java.lang.Thread.run(Thread.java:761)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426] 
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426] "HeapTaskDaemon" prio=6 tid=8 Blocked
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   | group="" sCount=1 dsCount=0 obj=0x12c3d3a0 self=0x7fa7a99200
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   | sysTid=15739 nice=0 cgrp=default sched=0/0 handle=0x7fa69fb450
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   | state=S schedstat=( 155717347 1272239 33 ) utm=13 stm=2 core=6 HZ=100
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   | stack=0x7fa68f9000-0x7fa68fb000 stackSize=1037KB
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   | held mutexes=
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: __switch_to+0x7c/0x88
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: futex_wait_queue_me+0xe4/0x144
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: futex_wait+0xfc/0x208
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: do_futex+0xdc/0x8a4
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: SyS_futex+0x114/0x1a0
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: cpu_switch_to+0x210/0x5a0
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #00 pc 000000000001c1b0  /system/lib64/libc.so (syscall+32)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #01 pc 00000000000e8168  /system/lib64/libart.so (_ZN3art17ConditionVariable9TimedWaitEPNS_6ThreadEli+176)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #02 pc 0000000000241384  /system/lib64/libart.so (_ZN3art2gc13TaskProcessor7GetTaskEPNS_6ThreadE+296)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #03 pc 0000000000241ca0  /system/lib64/libart.so (_ZN3art2gc13TaskProcessor11RunAllTasksEPNS_6ThreadE+92)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #04 pc 00000000001e6bb0  /system/framework/arm64/boot-core-libart.oat (Java_dalvik_system_VMRuntime_runHeapTasks__+124)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   at dalvik.system.VMRuntime.runHeapTasks(Native method)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   - waiting to lock an unknown object
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   at java.lang.Daemons$HeapTaskDaemon.run(Daemons.java:466)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   at java.lang.Thread.run(Thread.java:761)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426] 
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426] "Binder:15728_1" prio=6 tid=9 Native
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   | group="" sCount=1 dsCount=0 obj=0x12c3d550 self=0x7f98380400
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   | sysTid=15740 nice=0 cgrp=default sched=0/0 handle=0x7fa66f8450
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   | state=S schedstat=( 3793800 89323 16 ) utm=0 stm=0 core=4 HZ=100
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   | stack=0x7fa65fe000-0x7fa6600000 stackSize=1005KB
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   | held mutexes=
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: __switch_to+0x7c/0x88
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: binder_thread_read+0xe5c/0x102c
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: binder_ioctl_write_read+0x1c4/0x320
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: binder_ioctl+0x2a8/0x6f8
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: do_vfs_ioctl+0x4d0/0x5c4
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: SyS_ioctl+0x60/0x88
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: cpu_switch_to+0x210/0x5a0
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #00 pc 000000000006aca4  /system/lib64/libc.so (__ioctl+4)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #01 pc 000000000001fda0  /system/lib64/libc.so (ioctl+144)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #02 pc 0000000000055770  /system/lib64/libbinder.so (_ZN7android14IPCThreadState14talkWithDriverEb+260)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #03 pc 00000000000558d0  /system/lib64/libbinder.so (_ZN7android14IPCThreadState20getAndExecuteCommandEv+24)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #04 pc 0000000000055ffc  /system/lib64/libbinder.so (_ZN7android14IPCThreadState14joinThreadPoolEb+72)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #05 pc 000000000007420c  /system/lib64/libbinder.so (???)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #06 pc 0000000000012568  /system/lib64/libutils.so (_ZN7android6Thread11_threadLoopEPv+272)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #07 pc 00000000000a0c2c  /system/lib64/libandroid_runtime.so (_ZN7android14AndroidRuntime15javaThreadShellEPv+116)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #08 pc 000000000006881c  /system/lib64/libc.so (_ZL15__pthread_startPv+196)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #09 pc 000000000001de40  /system/lib64/libc.so (__start_thread+16)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   (no managed stack frames)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426] 
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426] "Binder:15728_2" prio=6 tid=10 Native
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   | group="" sCount=1 dsCount=0 obj=0x12c3d5e0 self=0x7f9f627800
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   | sysTid=15741 nice=0 cgrp=default sched=0/0 handle=0x7fa65fb450
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   | state=S schedstat=( 1741042 429375 16 ) utm=0 stm=0 core=0 HZ=100
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   | stack=0x7fa6501000-0x7fa6503000 stackSize=1005KB
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   | held mutexes=
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: __switch_to+0x7c/0x88
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: binder_thread_read+0xe5c/0x102c
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: binder_ioctl_write_read+0x1c4/0x320
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: binder_ioctl+0x2a8/0x6f8
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: do_vfs_ioctl+0x4d0/0x5c4
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: SyS_ioctl+0x60/0x88
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: cpu_switch_to+0x210/0x5a0
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #00 pc 000000000006aca4  /system/lib64/libc.so (__ioctl+4)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #01 pc 000000000001fda0  /system/lib64/libc.so (ioctl+144)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #02 pc 0000000000055770  /system/lib64/libbinder.so (_ZN7android14IPCThreadState14talkWithDriverEb+260)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #03 pc 00000000000558d0  /system/lib64/libbinder.so (_ZN7android14IPCThreadState20getAndExecuteCommandEv+24)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #04 pc 0000000000055ffc  /system/lib64/libbinder.so (_ZN7android14IPCThreadState14joinThreadPoolEb+72)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #05 pc 000000000007420c  /system/lib64/libbinder.so (???)
08-26 14:37:22.541 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #06 pc 0000000000012568  /system/lib64/libutils.so (_ZN7android6Thread11_threadLoopEPv+272)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #07 pc 00000000000a0c2c  /system/lib64/libandroid_runtime.so (_ZN7android14AndroidRuntime15javaThreadShellEPv+116)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #08 pc 000000000006881c  /system/lib64/libc.so (_ZL15__pthread_startPv+196)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #09 pc 000000000001de40  /system/lib64/libc.so (__start_thread+16)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   (no managed stack frames)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426] 
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426] "Profile Saver" prio=6 tid=11 Native
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   | group="" sCount=1 dsCount=0 obj=0x12c3d940 self=0x7f9838b800
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   | sysTid=15746 nice=-10 cgrp=default sched=0/0 handle=0x7f9fbbd450
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   | state=S schedstat=( 3759582 43333 20 ) utm=0 stm=0 core=5 HZ=100
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   | stack=0x7f9fac3000-0x7f9fac5000 stackSize=1005KB
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   | held mutexes=
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: __switch_to+0x7c/0x88
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: futex_wait_queue_me+0xe4/0x144
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: futex_wait+0xfc/0x208
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: do_futex+0xdc/0x8a4
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: SyS_futex+0x114/0x1a0
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: cpu_switch_to+0x210/0x5a0
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #00 pc 000000000001c1b0  /system/lib64/libc.so (syscall+32)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #01 pc 00000000000e8168  /system/lib64/libart.so (_ZN3art17ConditionVariable9TimedWaitEPNS_6ThreadEli+176)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #02 pc 000000000031ca2c  /system/lib64/libart.so (_ZN3art12ProfileSaver3RunEv+432)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #03 pc 000000000031e0bc  /system/lib64/libart.so (_ZN3art12ProfileSaver21RunProfileSaverThreadEPv+100)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #04 pc 000000000006881c  /system/lib64/libc.so (_ZL15__pthread_startPv+196)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #05 pc 000000000001de40  /system/lib64/libc.so (__start_thread+16)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   (no managed stack frames)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426] 
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426] "AsyncTask #1" prio=6 tid=13 TimedWaiting
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   | group="" sCount=1 dsCount=0 obj=0x12c80430 self=0x7f9f62dc00
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   | sysTid=15749 nice=10 cgrp=bg_non_interactive sched=0/0 handle=0x7f9f5ff450
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   | state=S schedstat=( 1346039 24895 13 ) utm=0 stm=0 core=4 HZ=100
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   | stack=0x7f9f4fd000-0x7f9f4ff000 stackSize=1037KB
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   | held mutexes=
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: __switch_to+0x7c/0x88
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: futex_wait_queue_me+0xe4/0x144
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: futex_wait+0xfc/0x208
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: do_futex+0xdc/0x8a4
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: SyS_futex+0x114/0x1a0
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: cpu_switch_to+0x210/0x5a0
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #00 pc 000000000001c1b0  /system/lib64/libc.so (syscall+32)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #01 pc 00000000000e8168  /system/lib64/libart.so (_ZN3art17ConditionVariable9TimedWaitEPNS_6ThreadEli+176)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #02 pc 000000000037a514  /system/lib64/libart.so (_ZN3art7Monitor4WaitEPNS_6ThreadElibNS_11ThreadStateE+676)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #03 pc 0000000000000980  /system/framework/arm64/boot.oat (Java_java_lang_Object_wait__JI+140)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   at java.lang.Object.wait!(Native method)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   - waiting on <0x0d9b0f47> (a java.lang.Object)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   at java.lang.Thread.parkFor$(Thread.java:2127)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   - locked <0x0d9b0f47> (a java.lang.Object)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   at sun.misc.Unsafe.park(Unsafe.java:325)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   at java.util.concurrent.locks.LockSupport.parkNanos(LockSupport.java:201)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.awaitNanos(AbstractQueuedSynchronizer.java:2077)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   at java.util.concurrent.LinkedBlockingQueue.poll(LinkedBlockingQueue.java:438)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   at java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1057)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1118)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:607)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   at java.lang.Thread.run(Thread.java:761)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426] 
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426] "RenderThread" prio=6 tid=15 Native
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   | group="" sCount=1 dsCount=0 obj=0x12d2eee0 self=0x7f9f7f8800
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   | sysTid=15794 nice=-10 cgrp=default sched=0/0 handle=0x7f8327f450
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   | state=S schedstat=( 25926096 1843179 63 ) utm=0 stm=2 core=6 HZ=100
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   | stack=0x7f83185000-0x7f83187000 stackSize=1005KB
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   | held mutexes=
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: __switch_to+0x7c/0x88
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: SyS_epoll_wait+0x2d4/0x394
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: SyS_epoll_pwait+0xc4/0x150
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: cpu_switch_to+0x210/0x5a0
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #00 pc 000000000006abb8  /system/lib64/libc.so (__epoll_pwait+8)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #01 pc 000000000001e574  /system/lib64/libc.so (epoll_pwait+64)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #02 pc 0000000000018160  /system/lib64/libutils.so (_ZN7android6Looper9pollInnerEi+156)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #03 pc 0000000000018014  /system/lib64/libutils.so (_ZN7android6Looper8pollOnceEiPiS1_PPv+60)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #04 pc 000000000003ade8  /system/lib64/libhwui.so (_ZN7android10uirenderer12renderthread12RenderThread10threadLoopEv+656)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #05 pc 0000000000012568  /system/lib64/libutils.so (_ZN7android6Thread11_threadLoopEPv+272)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #06 pc 00000000000a0c2c  /system/lib64/libandroid_runtime.so (_ZN7android14AndroidRuntime15javaThreadShellEPv+116)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #07 pc 000000000006881c  /system/lib64/libc.so (_ZL15__pthread_startPv+196)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #08 pc 000000000001de40  /system/lib64/libc.so (__start_thread+16)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   (no managed stack frames)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426] 
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426] "hwuiTask1" prio=6 tid=16 Native
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   | group="" sCount=1 dsCount=0 obj=0x12d540d0 self=0x7f86d80600
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   | sysTid=15795 nice=-2 cgrp=default sched=0/0 handle=0x7f7e9ff450
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   | state=S schedstat=( 972029 16406 5 ) utm=0 stm=0 core=6 HZ=100
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   | stack=0x7f7e905000-0x7f7e907000 stackSize=1005KB
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   | held mutexes=
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: __switch_to+0x7c/0x88
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: futex_wait_queue_me+0xe4/0x144
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: futex_wait+0xfc/0x208
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: do_futex+0xdc/0x8a4
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: SyS_futex+0x114/0x1a0
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: cpu_switch_to+0x210/0x5a0
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #00 pc 000000000001c1ac  /system/lib64/libc.so (syscall+28)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #01 pc 0000000000067f74  /system/lib64/libc.so (pthread_cond_wait+96)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #02 pc 000000000003bd0c  /system/lib64/libhwui.so (???)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #03 pc 0000000000012568  /system/lib64/libutils.so (_ZN7android6Thread11_threadLoopEPv+272)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #04 pc 00000000000a0c2c  /system/lib64/libandroid_runtime.so (_ZN7android14AndroidRuntime15javaThreadShellEPv+116)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #05 pc 000000000006881c  /system/lib64/libc.so (_ZL15__pthread_startPv+196)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #06 pc 000000000001de40  /system/lib64/libc.so (__start_thread+16)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   (no managed stack frames)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426] 
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426] "Binder:15728_3" prio=6 tid=17 Native
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   | group="" sCount=1 dsCount=0 obj=0x12d54160 self=0x7f9f714400
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   | sysTid=15798 nice=0 cgrp=default sched=0/0 handle=0x7f7e0fb450
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   | state=S schedstat=( 579010 13125 4 ) utm=0 stm=0 core=4 HZ=100
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   | stack=0x7f7e001000-0x7f7e003000 stackSize=1005KB
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   | held mutexes=
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: __switch_to+0x7c/0x88
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: binder_thread_read+0xe5c/0x102c
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: binder_ioctl_write_read+0x1c4/0x320
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: binder_ioctl+0x2a8/0x6f8
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: do_vfs_ioctl+0x4d0/0x5c4
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: SyS_ioctl+0x60/0x88
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   kernel: cpu_switch_to+0x210/0x5a0
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #00 pc 000000000006aca4  /system/lib64/libc.so (__ioctl+4)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #01 pc 000000000001fda0  /system/lib64/libc.so (ioctl+144)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #02 pc 0000000000055770  /system/lib64/libbinder.so (_ZN7android14IPCThreadState14talkWithDriverEb+260)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #03 pc 00000000000558d0  /system/lib64/libbinder.so (_ZN7android14IPCThreadState20getAndExecuteCommandEv+24)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #04 pc 0000000000055ffc  /system/lib64/libbinder.so (_ZN7android14IPCThreadState14joinThreadPoolEb+72)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #05 pc 000000000007420c  /system/lib64/libbinder.so (???)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #06 pc 0000000000012568  /system/lib64/libutils.so (_ZN7android6Thread11_threadLoopEPv+272)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #07 pc 00000000000a0c2c  /system/lib64/libandroid_runtime.so (_ZN7android14AndroidRuntime15javaThreadShellEPv+116)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #08 pc 000000000006881c  /system/lib64/libc.so (_ZL15__pthread_startPv+196)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   native: #09 pc 000000000001de40  /system/lib64/libc.so (__start_thread+16)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426]   (no managed stack frames)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426] 
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:426] 
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:431] JNI ERROR (app bug): local reference table overflow (max=512)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:431] local reference table dump:
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:431]   Last 10 entries (of 512):
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:431]       511: 0x12de87c0 java.lang.String "This is a long s... (85 chars)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:431]       510: 0x12df6340 java.lang.String "This is a long s... (85 chars)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:431]       509: 0x12de87c0 java.lang.String "This is a long s... (85 chars)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:431]       508: 0x12df6280 java.lang.String "This is a long s... (85 chars)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:431]       507: 0x12de87c0 java.lang.String "This is a long s... (85 chars)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:431]       506: 0x12df61c0 java.lang.String "This is a long s... (85 chars)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:431]       505: 0x12de87c0 java.lang.String "This is a long s... (85 chars)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:431]       504: 0x12df6100 java.lang.String "This is a long s... (85 chars)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:431]       503: 0x12de87c0 java.lang.String "This is a long s... (85 chars)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:431]       502: 0x12df5f40 java.lang.String "This is a long s... (85 chars)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:431]   Summary:
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:431]       511 of java.lang.String (257 unique instances)
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:431]         1 of java.lang.ClassNotFoundException
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:431] 
08-26 14:37:22.542 15728 15751 F art     : art/runtime/runtime.cc:431] 
08-26 14:37:22.543   470   470 W         : debuggerd: handling request: pid=15728 uid=12967 gid=12967 tid=15751
08-26 14:37:22.574  1589  1673 W qti_sensors_hal: timestampCalc: Adjusting timestamp for rollover: 472836871100175, -1
08-26 14:37:22.615 15812 15812 F DEBUG   : *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
08-26 14:37:22.615 15812 15812 F DEBUG   : Build fingerprint: 'vivo/PD1616/PD1616:7.1.2/N2G47H/compil12110227:user/release-keys'
08-26 14:37:22.615 15812 15812 F DEBUG   : Revision: '0'
08-26 14:37:22.615 15812 15812 F DEBUG   : ABI: 'arm64'
08-26 14:37:22.615 15812 15812 F DEBUG   : pid: 15728, tid: 15751, name: Thread-2  >>> com.dartnative.dart_native_example <<<
08-26 14:37:22.615 15812 15812 F DEBUG   : signal 6 (SIGABRT), code -6 (SI_TKILL), fault addr --------
08-26 14:37:22.616   876   876 I MSM-irqbalance: Decided to move IRQ3 from CPU2 [P:0] to CPU4 [P:1] (banned)
08-26 14:37:22.617   876   876 I MSM-irqbalance: Decided to move IRQ5 from CPU2 [P:0] to CPU5 [P:1] (banned)
08-26 14:37:22.618   876   876 I MSM-irqbalance: Decided to move IRQ5 from CPU0 [P:0] to CPU7 [P:1] (banned)
08-26 14:37:22.619   876   876 I MSM-irqbalance: Decided to move IRQ3 from CPU0 [P:0] to CPU6 [P:1] (banned)
08-26 14:37:22.620   876   876 I MSM-irqbalance: Decided to move IRQ5 from CPU1 [P:0] to CPU4 [P:1] (banned)
08-26 14:37:22.630 15812 15812 F DEBUG   : Abort message: 'art/runtime/indirect_reference_table.cc:132] JNI ERROR (app bug): local reference table overflow (max=512)'
08-26 14:37:22.630 15812 15812 F DEBUG   :     x0   0000000000000000  x1   0000000000003d87  x2   0000000000000006  x3   0000000000000008
08-26 14:37:22.630 15812 15812 F DEBUG   :     x4   000000000000012c  x5   0000008000000000  x6   0000000080000000  x7   1f1f1eff1f5c3032
08-26 14:37:22.630 15812 15812 F DEBUG   :     x8   0000000000000083  x9   ffffffffffffffdf  x10  0000000000000000  x11  0000000000000001
08-26 14:37:22.630 15812 15812 F DEBUG   :     x12  ffffffffffffffff  x13  ffffffffffffffff  x14  ffff000000000000  x15  ffffffffffffffff
08-26 14:37:22.630 15812 15812 F DEBUG   :     x16  0000007faa10eee0  x17  0000007faa0b8b88  x18  0000000000000000  x19  0000007f87ee94f8
08-26 14:37:22.630 15812 15812 F DEBUG   :     x20  0000000000000006  x21  0000007f87ee9450  x22  0000000000000000  x23  0000007fa7985e78
08-26 14:37:22.630 15812 15812 F DEBUG   :     x24  000000000000000a  x25  ffffffffffffffff  x26  00000000000003ab  x27  0000007f87ee79b1
08-26 14:37:22.630 15812 15812 F DEBUG   :     x28  0000007fa79fc760  x29  0000007f87ee78b0  x30  0000007faa0b6018
08-26 14:37:22.630 15812 15812 F DEBUG   :     sp   0000007f87ee7890  pc   0000007faa0b8b90  pstate 0000000060000000
08-26 14:37:22.645 15812 15812 F DEBUG   : 
08-26 14:37:22.645 15812 15812 F DEBUG   : backtrace:
08-26 14:37:22.645 15812 15812 F DEBUG   :     #00 pc 000000000006bb90  /system/lib64/libc.so (tgkill+8)
08-26 14:37:22.645 15812 15812 F DEBUG   :     #01 pc 0000000000069014  /system/lib64/libc.so (pthread_kill+64)
08-26 14:37:22.645 15812 15812 F DEBUG   :     #02 pc 00000000000241c0  /system/lib64/libc.so (raise+24)
08-26 14:37:22.645 15812 15812 F DEBUG   :     #03 pc 000000000001cc2c  /system/lib64/libc.so (abort+52)
08-26 14:37:22.645 15812 15812 F DEBUG   :     #04 pc 00000000004310a4  /system/lib64/libart.so (_ZN3art7Runtime5AbortEPKc+456)
08-26 14:37:22.645 15812 15812 F DEBUG   :     #05 pc 00000000000e5918  /system/lib64/libart.so (_ZN3art10LogMessageD2Ev+1576)
08-26 14:37:22.645 15812 15812 F DEBUG   :     #06 pc 000000000024c4b4  /system/lib64/libart.so (_ZN3art22IndirectReferenceTable3AddEjPNS_6mirror6ObjectE+308)
08-26 14:37:22.646 15812 15812 F DEBUG   :     #07 pc 0000000000349ac0  /system/lib64/libart.so (_ZN3art3JNI9NewStringEP7_JNIEnvPKti+628)
08-26 14:37:22.646 15812 15812 F DEBUG   :     #08 pc 00000000000f9e70  /system/lib64/libart.so (_ZN3art8CheckJNI9NewStringEP7_JNIEnvPKti+668)
08-26 14:37:22.646 15812 15812 F DEBUG   :     #09 pc 000000000003e28c  /data/app/com.dartnative.dart_native_example-1/lib/arm64/libdart_native.so (_ZN7_JNIEnv9NewStringEPKti+48)
08-26 14:37:22.646 15812 15812 F DEBUG   :     #10 pc 000000000003e20c  /data/app/com.dartnative.dart_native_example-1/lib/arm64/libdart_native.so (convertToJavaUtf16+124)
08-26 14:37:22.646 15812 15812 F DEBUG   :     #11 pc 000000000002fc18  /data/app/com.dartnative.dart_native_example-1/lib/arm64/libdart_native.so (_fillArgs+228)
08-26 14:37:22.646 15812 15812 F DEBUG   :     #12 pc 0000000000030188  /data/app/com.dartnative.dart_native_example-1/lib/arm64/libdart_native.so (invokeNativeMethod+212)